### PR TITLE
9 working with the time zone

### DIFF
--- a/Sources/SunKit/Extensions.swift
+++ b/Sources/SunKit/Extensions.swift
@@ -29,8 +29,6 @@ extension Date: Strideable {
     }
 }
 
-
-//TO DO: UT coverage
 extension Calendar {
     func numberOfDaysSinceStartOfTheYear(for date: Date) -> Int {
         let startOfTheYear: Date = startOfYear(date)

--- a/Sources/SunKit/HMS.swift
+++ b/Sources/SunKit/HMS.swift
@@ -26,10 +26,10 @@ public struct HMS: Equatable{
     public var minutes: Double
     public var seconds: Double
     
-    public init(from date: Date){
+    public init(from date: Date, timeZoneInSeconds: Int){
         
         var calendar: Calendar = .init(identifier: .gregorian)
-        calendar = .current
+        calendar.timeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
         
         self.hours = Double(calendar.component(.hour, from: date))
         self.minutes = Double(calendar.component(.minute, from: date))

--- a/Sources/SunKit/HorizonCoordinates.swift
+++ b/Sources/SunKit/HorizonCoordinates.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 
-
 public struct HorizonCoordinates{
     
     public var altitude: Angle

--- a/Sources/SunKit/Sun.swift
+++ b/Sources/SunKit/Sun.swift
@@ -28,19 +28,19 @@ public class Sun {
     public private(set) var timeZone: TimeZone
     public private(set) var date: Date = Date()
     
-    ///Date of Sunrise in local timezone
+    ///Date of Sunrise
     public private(set) var sunrise: Date = Date()
-    ///Date of Sunset in local timezone
+    ///Date of Sunset
     public private(set) var sunset: Date = Date()
-    ///Date of Solar Noon  in local timezone
+    ///Date of Solar Noon  for
     public private(set) var solarNoon: Date = Date()
-    ///Date at which Golden hour starts in local timezone
+    ///Date at which evening  Golden hour starts for instance timezone
     public private(set) var goldenHourStart: Date = Date()
-    ///Date at which Golden hour ends in local timezone
+    ///Date at which evening  Golden hour ends
     public private(set) var goldenHourEnd: Date = Date()
-    ///Date at which there is the first light  in local timezone
+    ///Date at which there is the first light
     public private(set) var firstLight: Date = Date()
-    ///Date at which there is the last light  in local timezone
+    ///Date at which there is the last light
     public private(set) var lastLight: Date = Date()
     ///Azimuth of Sunrise
     public private(set) var sunriseAzimuth: Double = 0
@@ -49,13 +49,13 @@ public class Sun {
     ///Azimuth of Solar noon
     public private(set) var solarNoonAzimuth: Double = 0
 
-    ///Date at which  there will be march equinox in local timezone
+    ///Date at which  there will be march equinox
     public private(set) var marchEquinox: Date = Date()
-    ///Date at which  there will be june solstice in locla timezone
+    ///Date at which  there will be june solstice
     public private(set) var juneSolstice: Date = Date()
-    ///Date at which  there will be september solstice in local timezone
+    ///Date at which  there will be september solstice
     public private(set) var septemberEquinox: Date = Date()
-    ///Date at which  there will be december solstice in local timezone
+    ///Date at which  there will be december solstice
     public private(set) var decemberSolstice: Date = Date()
     
     
@@ -132,6 +132,79 @@ public class Sun {
     }
     
     /*--------------------------------------------------------------------
+     Public methods
+     *-------------------------------------------------------------------*/
+    
+    public init(location: CLLocation,timeZone: Double) {
+        let timeZoneSeconds: Int = Int(timeZone * SECONDS_IN_ONE_HOUR)
+        self.timeZone = TimeZone.init(secondsFromGMT: timeZoneSeconds) ?? .current
+        self.location = location
+        refresh()
+    }
+    
+    public init(location: CLLocation,timeZone: TimeZone) {
+        self.timeZone = timeZone
+        self.location = location
+        refresh()
+    }
+    
+    public func setDate(_ newDate: Date) {
+        date = newDate
+        refresh()
+    }
+    
+    public func setLocation(_ newLocation: CLLocation) {
+        location = newLocation
+        refresh()
+    }
+    
+    public func setLocation(_ newLocation: CLLocation,_ newTimeZone: Double) {
+        let timeZoneSeconds: Int = Int(newTimeZone * SECONDS_IN_ONE_HOUR)
+        timeZone = TimeZone(secondsFromGMT: timeZoneSeconds) ?? .current
+        location = newLocation
+        changeCurrentDate()
+        refresh()
+    }
+    
+    public func setLocation(_ newLocation: CLLocation,_ newTimeZone: TimeZone) {
+        timeZone = newTimeZone
+        location = newLocation
+        changeCurrentDate()
+        refresh()
+    }
+    
+    public func setTimeZone(_ newTimeZone: Double) {
+        let timeZoneSeconds: Int = Int(newTimeZone * SECONDS_IN_ONE_HOUR)
+        timeZone = TimeZone(secondsFromGMT: timeZoneSeconds) ?? .current
+        changeCurrentDate()
+        refresh()
+    }
+    
+    public func setTimeZone(_ newTimeZone: TimeZone) {
+        timeZone = newTimeZone
+        changeCurrentDate()
+        refresh()
+    }
+    
+    /// Usefull function for debug
+    public func dumpDateInfos(){
+        
+        print("Current Date -> \(dateFormatter.string(from: date))")
+        print("Sunrise -> \(dateFormatter.string(from: sunrise))")
+        print("Sunset -> \(dateFormatter.string(from: sunset))")
+        print("Solar Noon -> \(dateFormatter.string(from: solarNoon))")
+        print("Golden Hour Start -> \(dateFormatter.string(from: goldenHourStart))")
+        print("Golden Hour End -> \(dateFormatter.string(from: goldenHourEnd))")
+        print("First Light -> \(dateFormatter.string(from: firstLight))")
+        print("Last Light -> \(dateFormatter.string(from: lastLight))")
+        print("March Equinox -> \(dateFormatter.string(from: marchEquinox))")
+        print("June Solstice -> \(dateFormatter.string(from: juneSolstice))")
+        print("September Equinox -> \(dateFormatter.string(from: septemberEquinox))")
+        print("December Solstice -> \(dateFormatter.string(from: decemberSolstice))")
+    
+    }
+    
+    /*--------------------------------------------------------------------
      Private Variables
      *-------------------------------------------------------------------*/
     
@@ -147,7 +220,7 @@ public class Sun {
         dateFormatter.locale = .current
         dateFormatter.timeZone = TimeZone.init(secondsFromGMT: timeZone.secondsFromGMT())
         dateFormatter.timeStyle = .full
-        //dateFormatter.dateFormat = "yyyy-MM-dd’T’HH:mm:ssZ"
+        dateFormatter.dateStyle = .full
         return dateFormatter
     }
     
@@ -197,7 +270,7 @@ public class Sun {
     }
     
     private var localStandardTimeMeridian: Double {
-        return (Double(timeZone.secondsFromGMT()) / SECONDS_IN_ONE_HOUR) * 15    //TimeZone in hour
+        return (Double(timeZone.secondsFromGMT()) / SECONDS_IN_ONE_HOUR) * 15  //TimeZone in hour
     }
     
     private var timeCorrectionFactorInSeconds: Double {
@@ -209,78 +282,6 @@ public class Sun {
         return timeCorrectionFactorInSeconds
     }
     
-    /*--------------------------------------------------------------------
-     Public methods
-     *-------------------------------------------------------------------*/
-    
-    public init(location: CLLocation,timeZone: Double) {
-        let timeZoneSeconds: Int = Int(timeZone * SECONDS_IN_ONE_HOUR)
-        self.timeZone = TimeZone.init(secondsFromGMT: timeZoneSeconds) ?? .current
-        self.location = location
-        refresh()
-    }
-    
-    public init(location: CLLocation,timeZone: TimeZone) {
-        self.timeZone = timeZone
-        self.location = location
-        refresh()
-    }
-    
-    public func setDate(_ newDate: Date) {
-        date = newDate
-        refresh()
-    }
-    
-    public func setLocation(_ newLocation: CLLocation) {
-        location = newLocation
-        refresh()
-    }
-    
-    // current date needs to be changed before call refresh
-    public func setLocation(_ newLocation: CLLocation,_ newTimeZone: Double) {
-        let timeZoneSeconds: Int = Int(newTimeZone * SECONDS_IN_ONE_HOUR)
-        timeZone = TimeZone(secondsFromGMT: timeZoneSeconds) ?? .current
-        location = newLocation
-        changeCurrentDate()
-        refresh()
-    }
-    
-    public func setLocation(_ newLocation: CLLocation,_ newTimeZone: TimeZone) {
-        timeZone = newTimeZone
-        location = newLocation
-        changeCurrentDate()
-        refresh()
-    }
-    
-    public func setTimeZone(_ newTimeZone: Double) {
-        let timeZoneSeconds: Int = Int(newTimeZone * SECONDS_IN_ONE_HOUR)
-        timeZone = TimeZone(secondsFromGMT: timeZoneSeconds) ?? .current
-        changeCurrentDate()
-        refresh()
-    }
-    
-    public func setTimeZone(_ newTimeZone: TimeZone) {
-        timeZone = newTimeZone
-        changeCurrentDate()
-        refresh()
-    }
-    
-    public func dumpDateInfos(){
-        
-        print("Current Date -> \(dateFormatter.string(from: date))")
-        print("Sunrise -> \(dateFormatter.string(from: sunrise))")
-        print("Sunset -> \(dateFormatter.string(from: sunset))")
-        print("Solar Noon -> \(dateFormatter.string(from: solarNoon))")
-        print("Golden Hour Start -> \(dateFormatter.string(from: goldenHourStart))")
-        print("Golden Hour End -> \(dateFormatter.string(from: goldenHourEnd))")
-        print("First Light -> \(dateFormatter.string(from: firstLight))")
-        print("Last Light -> \(dateFormatter.string(from: lastLight))")
-        print("marchEquinox -> \(dateFormatter.string(from: marchEquinox))")
-        print("juneSolstice -> \(dateFormatter.string(from: juneSolstice))")
-        print("septemberEquinox -> \(dateFormatter.string(from: septemberEquinox))")
-        print("decemberSolstice -> \(dateFormatter.string(from: decemberSolstice))")
-    
-    }
     
     /*--------------------------------------------------------------------
      Private methods
@@ -313,11 +314,8 @@ public class Sun {
     
     /// function called after timezone changes in order to change the date accordingly
     private func changeCurrentDate(){
-
         let components = calendar.dateComponents(in: self.timeZone, from: self.date)
-        
         self.date = calendar.date(from: components) ?? self.date
-        
     }
     
     private func getSunMeanAnomaly(from elapsedDaysSinceStandardEpoch: Double) -> Angle {
@@ -583,9 +581,7 @@ public class Sun {
         let julianDayMarchEquinox: Double = 1721139.2855 + 365.2421376 * year + 0.0679190 * pow(t, 2) - 0.0027879 * pow(t, 3)
         
         let marchEquinoxUTC = dateFromJd(jd: julianDayMarchEquinox)
-        
         let components = calendar.dateComponents(in: self.timeZone, from: marchEquinoxUTC)
-        
         return calendar.date(from: components) ?? Date()
     }
     
@@ -596,9 +592,7 @@ public class Sun {
         let julianDayJuneSolstice: Double = 1721233.2486 + 365.2417284 * year - 0.0530180 * pow(t, 2) + 0.0093320 * pow(t, 3)
         
         let juneSolsticeUTC = dateFromJd(jd: julianDayJuneSolstice)
-        
         let components = calendar.dateComponents(in: self.timeZone, from: juneSolsticeUTC)
-        
         return calendar.date(from: components) ?? Date()
         
     }
@@ -610,9 +604,7 @@ public class Sun {
         let julianDaySeptemberEquinox: Double = 1721325.6978 + 365.2425055 * year - 0.126689 * pow(t, 2) + 0.0019401 * pow(t, 3)
         
         let septemberEquinoxUTC = dateFromJd(jd: julianDaySeptemberEquinox)
-        
         let components = calendar.dateComponents(in: self.timeZone, from: septemberEquinoxUTC)
-        
         return calendar.date(from: components) ?? Date()
     }
     
@@ -623,9 +615,7 @@ public class Sun {
         let julianDayDecemberSolstice: Double = 1721414.3920 + 365.2428898 * year - 0.0109650 * pow(t, 2) - 0.0084885 * pow(t, 3)
         
         let decemberSolsticeUTC = dateFromJd(jd: julianDayDecemberSolstice)
-        
         let components = calendar.dateComponents(in: self.timeZone, from: decemberSolsticeUTC)
-        
         return calendar.date(from: components) ?? Date()
     }
 

--- a/Tests/SunKitTests/UT_Sun.swift
+++ b/Tests/SunKitTests/UT_Sun.swift
@@ -58,6 +58,34 @@ final class UT_Sun: XCTestCase {
     static let timeZoneTromso = 1
     static let timeZoneTromsoDaylightSaving = 2
     
+    
+    /// Test of  a sun ionstance whenm you play with timezones and change location
+    /// Value for expected results have been taken from SunCalc.org
+    func testOfSunWhenTimezoneChanges() throws {
+        
+        //Step1: Creating Sun instance in Naples and with timezone +1
+        var timeZoneNaples: TimeZone = .init(secondsFromGMT: UT_Sun.timeZoneNaples * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        var sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: timeZoneNaples)
+        
+        //Step2: Setting 19/11/22 20:00 as date. (No daylight saving)
+        var dateUnderTest = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 20, minute: 00, seconds: 00,timeZone: timeZoneNaples)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Change location and timezone
+        let timeZoneTokyo: TimeZone = .init(secondsFromGMT: UT_Sun.timeZoneTokyo * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        sunUnderTest.setLocation(UT_Sun.tokyoLocation, timeZoneTokyo)
+        
+        //Step4: Saving expected outputs for all the date
+        var expectedDate = createDateCustomTimeZone(day: 20, month: 11, year: 2022, hour: 4, minute: 00, seconds: 00,timeZone: timeZoneTokyo)
+        
+        //Step5: Check if output of sun matches the expected output
+        XCTAssertTrue(expectedDate == sunUnderTest.date)
+        
+    
+        
+    }
+    
+    
     /// Test of  Sun azimuth, sunrise, sunset, afternoon golden hour start and afternoon golden hour end
     /// Value for expected results have been taken from SunCalc.org
     func testOfSun() throws {
@@ -69,26 +97,27 @@ final class UT_Sun: XCTestCase {
         //Test1: 19/11/22 20:00. Timezone +1.
         
         //Step1: Creating Sun instance in Naples and with timezone +1
-        var sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: Double(UT_Sun.timeZoneNaples))
+        var timeZoneUnderTest: TimeZone = .init(secondsFromGMT: UT_Sun.timeZoneNaples * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        var sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 19/11/22 20:00 as date. (No daylight saving)
-        var dateUnderTest = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 20, minute: 00, seconds: 00)
+        var dateUnderTest = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 20, minute: 00, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
         
         //Step3: Saving expected outputs
         var expectedAzimuth = 275.84
         var expectedAltitude = -37.34
         
-        var expectedSunRise = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 54, seconds: 12)
-        var expectedSunset = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 42, seconds: 07)
+        var expectedSunRise = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 54, seconds: 12,timeZone: timeZoneUnderTest)
+        var expectedSunset = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 42, seconds: 07,timeZone: timeZoneUnderTest)
         
-        var expectedGoldenHourStart = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 00, seconds: 00)
-        var expectedGoldenHourEnd = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 59, seconds: 00)
+        var expectedGoldenHourStart = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 00, seconds: 00,timeZone: timeZoneUnderTest)
+        var expectedGoldenHourEnd = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 59, seconds: 00,timeZone: timeZoneUnderTest)
         
-        var expectedFirstLight = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 24, seconds: 51)
-        var expectedLastLight = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 17, minute: 11, seconds: 28)
+        var expectedFirstLight = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 24, seconds: 51,timeZone: timeZoneUnderTest)
+        var expectedLastLight = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 17, minute: 11, seconds: 28,timeZone: timeZoneUnderTest)
         
-        var expectedSolarNoon = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 11, minute: 48, seconds: 21)
+        var expectedSolarNoon = createDateCustomTimeZone(day: 19, month: 11, year: 2022, hour: 11, minute: 48, seconds: 21,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         
@@ -110,26 +139,28 @@ final class UT_Sun: XCTestCase {
         //Test: 31/12/2024 15:32. Timezone +1. Leap Year.
         
         //Step1: Creating Sun instance in Naples and with timezone +1
-        sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: Double(UT_Sun.timeZoneNaples))
+        timeZoneUnderTest = .init(secondsFromGMT: UT_Sun.timeZoneNaples * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        
+        sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 31/12/2024 15:32 as date. (No daylight saving)
-        dateUnderTest = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 15, minute: 32, seconds: 00)
+        dateUnderTest = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 15, minute: 32, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
         
         //Step3: Saving expected outputs
         expectedAzimuth = 226.99
         expectedAltitude = 10.35
         
-        expectedSunRise = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 7, minute: 26, seconds: 57)
-        expectedSunset = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 45, seconds: 32)
+        expectedSunRise = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 7, minute: 26, seconds: 57,timeZone: timeZoneUnderTest)
+        expectedSunset = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 45, seconds: 32,timeZone: timeZoneUnderTest)
         
-        expectedGoldenHourStart = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 02, seconds: 00)
-        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 05, seconds: 00)
+        expectedGoldenHourStart = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 02, seconds: 00,timeZone: timeZoneUnderTest)
+        expectedGoldenHourEnd = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 05, seconds: 00,timeZone: timeZoneUnderTest)
         
-        expectedFirstLight = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 6, minute: 56, seconds: 24)
-        expectedLastLight = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 16, seconds: 06)
+        expectedFirstLight = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 6, minute: 56, seconds: 24,timeZone: timeZoneUnderTest)
+        expectedLastLight = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 16, seconds: 06,timeZone: timeZoneUnderTest)
         
-        expectedSolarNoon = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 12, minute: 06, seconds: 11)
+        expectedSolarNoon = createDateCustomTimeZone(day: 31, month: 12, year: 2024, hour: 12, minute: 06, seconds: 11,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         
@@ -155,26 +186,27 @@ final class UT_Sun: XCTestCase {
         //Test: 1/08/22 16:50. Timezone +9.
         
         //Step1: Creating sun instance in Tokyo and with timezone +9
-        sunUnderTest = Sun.init(location: UT_Sun.tokyoLocation, timeZone: Double(UT_Sun.timeZoneTokyo))
+        timeZoneUnderTest = .init(secondsFromGMT: UT_Sun.timeZoneTokyo * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        sunUnderTest = Sun.init(location: UT_Sun.tokyoLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 1/08/22 16:50 as date.
-        dateUnderTest = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 16, minute: 50, seconds: 00)
+        dateUnderTest = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 16, minute: 50, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
         
         //Step3: Saving expected outputs
         expectedAzimuth = 276.98
         expectedAltitude = 21.90
         
-        expectedSunRise = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 48, seconds: 29)
-        expectedSunset = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 46, seconds: 15)
+        expectedSunRise = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 48, seconds: 29,timeZone: timeZoneUnderTest)
+        expectedSunset = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 46, seconds: 15,timeZone: timeZoneUnderTest)
         
-        expectedGoldenHourStart = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 11, seconds: 00)
-        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 04, seconds: 00)
+        expectedGoldenHourStart = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 11, seconds: 00,timeZone: timeZoneUnderTest)
+        expectedGoldenHourEnd = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 04, seconds: 00,timeZone: timeZoneUnderTest)
         
-        expectedFirstLight = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 20, seconds: 39)
-        expectedLastLight = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 14, seconds: 00)
+        expectedFirstLight = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 20, seconds: 39,timeZone: timeZoneUnderTest)
+        expectedLastLight = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 14, seconds: 00,timeZone: timeZoneUnderTest)
         
-        expectedSolarNoon = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 11, minute: 47, seconds: 36)
+        expectedSolarNoon = createDateCustomTimeZone(day: 1, month: 8, year: 2022, hour: 11, minute: 47, seconds: 36,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         
@@ -199,26 +231,27 @@ final class UT_Sun: XCTestCase {
         //Test:  1/01/15 22:00. Timezone -5.
         
         //Step1: Creating sun instance in Louisa and with timezone -5 (No daylight saving)
-        sunUnderTest = Sun.init(location: UT_Sun.louisaLocation, timeZone: Double(UT_Sun.timeZoneLouisa))
+        timeZoneUnderTest = .init(secondsFromGMT: UT_Sun.timeZoneLouisa * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        sunUnderTest = Sun.init(location: UT_Sun.louisaLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 1/01/15 22:00 as date. (No daylight saving)
-        dateUnderTest = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 22, minute: 00, seconds: 00)
+        dateUnderTest = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 22, minute: 00, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
 
         //Step3: Saving expected outputs
         expectedAzimuth = 287.62
         expectedAltitude = -57.41
         
-        expectedSunRise = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 7, minute: 27, seconds: 29)
-        expectedSunset = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 03, seconds: 25)
+        expectedSunRise = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 7, minute: 27, seconds: 29,timeZone: timeZoneUnderTest)
+        expectedSunset = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 03, seconds: 25,timeZone: timeZoneUnderTest)
         
-        expectedGoldenHourStart = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 16, minute: 22, seconds: 00)
-        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 22, seconds: 00)
+        expectedGoldenHourStart = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 16, minute: 22, seconds: 00,timeZone: timeZoneUnderTest)
+        expectedGoldenHourEnd = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 22, seconds: 00,timeZone: timeZoneUnderTest)
         
-        expectedFirstLight = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 6, minute: 58, seconds: 28)
-        expectedLastLight = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 32, seconds: 27)
+        expectedFirstLight = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 6, minute: 58, seconds: 28,timeZone: timeZoneUnderTest)
+        expectedLastLight = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 32, seconds: 27,timeZone: timeZoneUnderTest)
         
-        expectedSolarNoon = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 12, minute: 15, seconds: 23)
+        expectedSolarNoon = createDateCustomTimeZone(day: 1, month: 1, year: 2015, hour: 12, minute: 15, seconds: 23,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         
@@ -243,22 +276,23 @@ final class UT_Sun: XCTestCase {
         //Test: 19/01/22 17:31. Timezone +1.
         
         //Step1: Creating sun instance in Tromso and with timezone +1 (No daylight saving)
-        sunUnderTest = Sun.init(location: UT_Sun.tromsoLocation, timeZone: Double(UT_Sun.timeZoneTromso))
+        timeZoneUnderTest = .init(secondsFromGMT: UT_Sun.timeZoneTromso * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        sunUnderTest = Sun.init(location: UT_Sun.tromsoLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 19/01/22 17:31 as date. (No daylight saving)
-        dateUnderTest = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 17, minute: 31, seconds: 00)
+        dateUnderTest = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 17, minute: 31, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
         
         //Step3: Saving expected outputs
         expectedAzimuth = 257.20
         expectedAltitude = -16.93
         
-        expectedSunRise = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 10, minute: 41, seconds: 46)
-        expectedSunset = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 13, minute: 08, seconds: 48)
-        expectedFirstLight = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 08, minute: 45, seconds: 30)
-        expectedLastLight = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 15, minute: 05, seconds: 08)
+        expectedSunRise = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 10, minute: 41, seconds: 46,timeZone: timeZoneUnderTest)
+        expectedSunset = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 13, minute: 08, seconds: 48,timeZone: timeZoneUnderTest)
+        expectedFirstLight = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 08, minute: 45, seconds: 30,timeZone: timeZoneUnderTest)
+        expectedLastLight = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 15, minute: 05, seconds: 08,timeZone: timeZoneUnderTest)
         
-        expectedSolarNoon = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 11, minute: 54, seconds: 52)
+        expectedSolarNoon = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 11, minute: 54, seconds: 52,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         
@@ -278,23 +312,25 @@ final class UT_Sun: XCTestCase {
         //Test: 19/01/22 17:31. Timezone +1. Naples
         
         //Step1: Creating sun instance in Naples and with timezone +1 (No daylight saving)
-        let sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: Double(UT_Sun.timeZoneNaples))
+        let timeZoneUnderTest: TimeZone = .init(secondsFromGMT: UT_Sun.timeZoneNaples * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        let timeZoneDaylightSaving: TimeZone = .init(secondsFromGMT: UT_Sun.timeZoneNaplesDaylightSaving * Int(SECONDS_IN_ONE_HOUR)) ?? .current
+        let sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: timeZoneUnderTest)
         
         //Step2: Setting 19/01/22 17:31 as date. (No daylight saving)
-        let dateUnderTest = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 17, minute: 31, seconds: 00)
+        let dateUnderTest = createDateCustomTimeZone(day: 19, month: 1, year: 2022, hour: 17, minute: 31, seconds: 00,timeZone: timeZoneUnderTest)
         sunUnderTest.setDate(dateUnderTest)
         
         //Step3: Saving expected outputs
     
-        var expectedMarchEquinox = createDateCurrentTimeZone(day: 20, month: 3, year: 2022, hour: 16, minute: 33, seconds: 00)
-        var expectedJuneSolstice = createDateCurrentTimeZone(day: 21, month: 6, year: 2022, hour: 11, minute: 13, seconds: 00)
-        var expectedSeptemberEquinox = createDateCurrentTimeZone(day: 23, month: 09, year: 2022, hour: 03, minute: 03, seconds: 00)
-        var expectedDecemberSolstice = createDateCurrentTimeZone(day: 21, month: 12, year: 2022, hour: 22, minute: 47, seconds: 00)
+        let expectedMarchEquinox = createDateCustomTimeZone(day: 20, month: 3, year: 2022, hour: 16, minute: 33, seconds: 00,timeZone: timeZoneUnderTest)
+        let expectedJuneSolstice = createDateCustomTimeZone(day: 21, month: 6, year: 2022, hour: 11, minute: 13, seconds: 00,timeZone: timeZoneDaylightSaving)
+        let expectedSeptemberEquinox = createDateCustomTimeZone(day: 23, month: 09, year: 2022, hour: 03, minute: 03, seconds: 00,timeZone: timeZoneDaylightSaving)
+        let expectedDecemberSolstice = createDateCustomTimeZone(day: 21, month: 12, year: 2022, hour: 22, minute: 47, seconds: 00,timeZone: timeZoneUnderTest)
 
         //Step4: Check if the output are close to the expected ones
         XCTAssertTrue(abs(expectedMarchEquinox.timeIntervalSince1970 - sunUnderTest.marchEquinox.timeIntervalSince1970)
                       <  UT_Sun.sunEquinoxesAndSolsticesThresholdInSeconds)
-        
+ 
         XCTAssertTrue(abs(expectedJuneSolstice.timeIntervalSince1970 - sunUnderTest.juneSolstice.timeIntervalSince1970)
                       <  UT_Sun.sunEquinoxesAndSolsticesThresholdInSeconds)
         
@@ -303,6 +339,10 @@ final class UT_Sun: XCTestCase {
        
         XCTAssertTrue(abs(expectedDecemberSolstice.timeIntervalSince1970 - sunUnderTest.decemberSolstice.timeIntervalSince1970)
                       <  UT_Sun.sunEquinoxesAndSolsticesThresholdInSeconds)
+        
+        
+        
+        
         
     }
     

--- a/Tests/SunKitTests/UT_Sun.swift
+++ b/Tests/SunKitTests/UT_Sun.swift
@@ -58,9 +58,14 @@ final class UT_Sun: XCTestCase {
     static let timeZoneTromso = 1
     static let timeZoneTromsoDaylightSaving = 2
     
+    /*--------------------------------------------------------------------
+     Mumbai  timezone and location
+     *-------------------------------------------------------------------*/
+    static let mumbaiLocation: CLLocation = .init(latitude: 18.94017, longitude: 72.83489)
+    static let timeZoneMumbai = 5.5
+    
     
     /// Test of  a sun ionstance whenm you play with timezones and change location
-    /// Value for expected results have been taken from SunCalc.org
     func testOfSunWhenTimezoneChanges() throws {
         
         //Step1: Creating Sun instance in Naples and with timezone +1
@@ -78,7 +83,7 @@ final class UT_Sun: XCTestCase {
         //Step4: Saving expected outputs for all the date
         var expectedDate = createDateCustomTimeZone(day: 20, month: 11, year: 2022, hour: 4, minute: 00, seconds: 00,timeZone: timeZoneTokyo)
         
-        //Step5: Check if output of sun matches the expected output
+        //Step5: Check if output of sunUnderTest.date matches the expected output
         XCTAssertTrue(expectedDate == sunUnderTest.date)
         
     
@@ -305,6 +310,34 @@ final class UT_Sun: XCTestCase {
         XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
         XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
         
+        
+        /*--------------------------------------------------------------------
+         Mumbai
+         *-------------------------------------------------------------------*/
+        
+        //Test: 12/03/23 14:46. Timezone +5.5.
+        
+        //Step1: Creating Sun instance in Mumbai and with timezone +5.5
+        timeZoneUnderTest = .init(secondsFromGMT: Int(UT_Sun.timeZoneMumbai * SECONDS_IN_ONE_HOUR)) ?? .current
+        sunUnderTest = Sun.init(location: UT_Sun.mumbaiLocation, timeZone: timeZoneUnderTest)
+        
+        //Step2: Setting 12/03/23 14:46 as date.
+        dateUnderTest = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 14, minute: 46, seconds: 00,timeZone: timeZoneUnderTest)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Saving expected outputs
+        expectedAzimuth = 235.41
+        expectedAltitude = 53.51
+        
+        expectedSunRise = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 6, minute: 49, seconds: 35,timeZone: timeZoneUnderTest)
+        expectedSunset = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 18, minute: 47, seconds: 42,timeZone: timeZoneUnderTest)
+        expectedFirstLight = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 6, minute: 27, seconds: 59,timeZone: timeZoneUnderTest)
+        expectedLastLight = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 19, minute: 09, seconds: 19,timeZone: timeZoneUnderTest)
+        
+        expectedSolarNoon = createDateCustomTimeZone(day: 12, month: 3, year: 2023, hour: 12, minute: 48, seconds: 31,timeZone: timeZoneUnderTest)
+
+        //Step4: Check if the output are close to the expected ones
+        
     }
     
     func testOfEquinoxesAndSolstices() throws {
@@ -340,8 +373,7 @@ final class UT_Sun: XCTestCase {
         XCTAssertTrue(abs(expectedDecemberSolstice.timeIntervalSince1970 - sunUnderTest.decemberSolstice.timeIntervalSince1970)
                       <  UT_Sun.sunEquinoxesAndSolsticesThresholdInSeconds)
         
-        
-        
+    
         
         
     }

--- a/Tests/SunKitTests/UT_Utils.swift
+++ b/Tests/SunKitTests/UT_Utils.swift
@@ -65,18 +65,6 @@ final class UT_Utils: XCTestCase {
         XCTAssertTrue(expectedOutput == dateFromJd(jd: jdNumberTest))
     }
 
-    /// Test of decimal2Date
-    func testOfdecimal2Date() throws{
-        
-      //Test1: 20.352h of 1 january 2015 shall returns date 01/01/2015 20:21:07
-        //Step1: Creating decimalNumberUnderTest
-        let decimalNumberUnderTest = 20.352
-        
-        //Step2: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        let expectedOutput = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 20, minute: 21, seconds: 7)
-    
-        XCTAssertTrue((expectedOutput.timeIntervalSince1970 - decimal2Date(decimalNumberUnderTest, day: 1, month: 1, year: 2015).timeIntervalSince1970) <= 2)
-    }
     
     /// Test of lCT2UT
     func testOflCT2UT() throws{
@@ -167,7 +155,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 8, minute: 41, seconds: 53)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - uT2GST(dateUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - uT2GST(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
     }
     
     /// Test of gST2UT
@@ -182,7 +170,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 23, minute: 30, seconds: 00)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2UT(dateUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2UT(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
     }
     
     /// Test of gST2LST
@@ -198,7 +186,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 6, month: 2, year: 2010, hour: 23, minute: 23, seconds: 41)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2LST(dateUnderTest, longitude: longitudeUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2LST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
     }
     
     /// Test of lST2GST
@@ -214,7 +202,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 20, minute: 3, seconds: 41)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lST2GST(dateUnderTest, longitude: longitudeUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lST2GST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
     }
     
 }


### PR DESCRIPTION
1. Improved the way SunKit handles the timezones: calendar is not anymore based on current timezone used on your device, but on the timezone inside the object of type Sun.

2.Added new public methods:  

-    `setLocation(_ newLocation: CLLocation,_ newTimeZone: Double)` 
-    `init(location: CLLocation,timeZone: TimeZone)`
-    `setLocation(_ newLocation: CLLocation,_ newTimeZone: TimeZone)`
-    `setTimeZone(_ newTimeZone: TimeZone)`
-    `dumpDateInfos()`, function useful to debug

3. Now whenever you try to change timezone `self.date` will move accordingly to the new timezone.
4. Added new UTs
