### PR TITLE
Backwards compatibility guarantee

### DIFF
--- a/Sources/SunKit/HMS.swift
+++ b/Sources/SunKit/HMS.swift
@@ -26,10 +26,10 @@ public struct HMS: Equatable{
     public var minutes: Double
     public var seconds: Double
     
-    public init(from date: Date, timeZoneInSeconds: Int){
+    public init(from date: Date, timeZoneInSeconds: Int,useSameTimeZone: Bool){
         
         var calendar: Calendar = .init(identifier: .gregorian)
-        calendar.timeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+        calendar.timeZone = useSameTimeZone ?  .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
         
         self.hours = Double(calendar.component(.hour, from: date))
         self.minutes = Double(calendar.component(.minute, from: date))

--- a/Sources/SunKit/Sun.swift
+++ b/Sources/SunKit/Sun.swift
@@ -26,6 +26,7 @@ public class Sun {
     
     public private(set) var location: CLLocation
     public private(set) var timeZone: TimeZone
+    public private(set) var useSameTimeZone: Bool
     public private(set) var date: Date = Date()
     
     ///Date of Sunrise
@@ -135,16 +136,18 @@ public class Sun {
      Public methods
      *-------------------------------------------------------------------*/
     
-    public init(location: CLLocation,timeZone: Double) {
+    public init(location: CLLocation,timeZone: Double,useSameTimeZone: Bool = false) {
         let timeZoneSeconds: Int = Int(timeZone * SECONDS_IN_ONE_HOUR)
         self.timeZone = TimeZone.init(secondsFromGMT: timeZoneSeconds) ?? .current
         self.location = location
+        self.useSameTimeZone = useSameTimeZone
         refresh()
     }
     
-    public init(location: CLLocation,timeZone: TimeZone) {
+    public init(location: CLLocation,timeZone: TimeZone,useSameTimeZone: Bool = false) {
         self.timeZone = timeZone
         self.location = location
+        self.useSameTimeZone = useSameTimeZone
         refresh()
     }
     
@@ -210,7 +213,7 @@ public class Sun {
     
     private var calendar: Calendar {
         var calendar: Calendar = .init(identifier: .gregorian)
-        calendar.timeZone = self.timeZone
+        calendar.timeZone =  useSameTimeZone ?  .current : self.timeZone
         
         return calendar
     }
@@ -344,11 +347,11 @@ public class Sun {
     private func updateSunCoordinates() {
         //Step1:
         //Convert LCT to UT, GST, and LST times and adjust the date if needed
-        let utDate = lCT2UT(self.date, timeZoneInSeconds: self.timeZoneInSeconds)
-        let gstDate = uT2GST(utDate, timeZoneInSeconds: self.timeZoneInSeconds)
-        let lstDate = gST2LST(gstDate,longitude: longitude,  timeZoneInSeconds: self.timeZoneInSeconds)
+        let utDate = lCT2UT(self.date, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
+        let gstDate = uT2GST(utDate, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
+        let lstDate = gST2LST(gstDate,longitude: longitude,  timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
         
-        let lstDecimal = HMS.init(from: lstDate, timeZoneInSeconds: self.timeZoneInSeconds).hMS2Decimal()
+        let lstDecimal = HMS.init(from: lstDate, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone).hMS2Decimal()
         
         //Step2:
         //Julian number for standard epoch 2000
@@ -396,11 +399,11 @@ public class Sun {
     public func getSunHorizonCoordinatesFrom(date: Date) -> HorizonCoordinates {
         //Step1:
         //Convert LCT to UT, GST, and LST times and adjust the date if needed
-        let utDate = lCT2UT(date, timeZoneInSeconds: self.timeZoneInSeconds)
-        let gstDate = uT2GST(utDate, timeZoneInSeconds: self.timeZoneInSeconds)
-        let lstDate = gST2LST(gstDate,longitude: longitude, timeZoneInSeconds: self.timeZoneInSeconds)
+        let utDate = lCT2UT(date, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
+        let gstDate = uT2GST(utDate, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
+        let lstDate = gST2LST(gstDate,longitude: longitude, timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone)
         
-        let lstDecimal = HMS.init(from: lstDate,timeZoneInSeconds: self.timeZoneInSeconds).hMS2Decimal()
+        let lstDecimal = HMS.init(from: lstDate,timeZoneInSeconds: self.timeZoneInSeconds,useSameTimeZone: self.useSameTimeZone).hMS2Decimal()
         
         //Step2:
         //Julian number for standard epoch 2000

--- a/Sources/SunKit/Utils.swift
+++ b/Sources/SunKit/Utils.swift
@@ -171,13 +171,13 @@ public func jdFromDate(date : Date) -> Double {
 /// - Parameter lct: Local civil time date
 /// - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: UT equivalent for the LCT given in input.
-public func lCT2UT(_ lct: Date, timeZoneInSeconds: Int) -> Date{
+public func lCT2UT(_ lct: Date, timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ?  .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
-    var lctDecimal = HMS.init(from: lct,timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    var lctDecimal = HMS.init(from: lct,timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     lctDecimal = lctDecimal - Double(timeZoneInSeconds) / 3600
    
@@ -211,13 +211,13 @@ public func lCT2UT(_ lct: Date, timeZoneInSeconds: Int) -> Date{
 /// - Parameter lct: Local civil time date
 /// - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: LCT equivalent for the UT given in input.
-public func UT2LCT(_ ut: Date,timeZoneInSeconds: Int) -> Date{
+public func UT2LCT(_ ut: Date,timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ?  .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
-    var utDecimal = HMS.init(from: ut, timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    var utDecimal = HMS.init(from: ut, timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     utDecimal = utDecimal + Double(timeZoneInSeconds) / 3600.0
     
@@ -251,13 +251,13 @@ public func UT2LCT(_ ut: Date,timeZoneInSeconds: Int) -> Date{
 /// - Parameter ut: UT time to convert in GST
 /// - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: GST equivalent of the UT given in input
-public func uT2GST(_ ut:Date,timeZoneInSeconds: Int) -> Date{
+public func uT2GST(_ ut:Date,timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendarUTC: Calendar = .init(identifier: .gregorian)
     calendarUTC.timeZone = .init(secondsFromGMT: 0)!
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ? .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
     //Step1:
@@ -284,7 +284,7 @@ public func uT2GST(_ ut:Date,timeZoneInSeconds: Int) -> Date{
     let TZero = 0.0657098 * days - B
     
     //Step8:
-    let utDecimal =  HMS.init(from: ut, timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    let utDecimal =  HMS.init(from: ut, timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     //Step9:
     var gstDecimal = TZero + 1.002738 * utDecimal
@@ -319,13 +319,13 @@ public func uT2GST(_ ut:Date,timeZoneInSeconds: Int) -> Date{
 /// - Parameter gst: GST time to convert in UT
 /// - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: UT equivalent of the GST given in input
-public func gST2UT(_ gst:Date,timeZoneInSeconds: Int) -> Date{
+public func gST2UT(_ gst:Date,timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendarUTC: Calendar = .init(identifier: .gregorian)
     calendarUTC.timeZone = .init(secondsFromGMT: 0)!
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ? .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
     //Step1:
@@ -358,7 +358,7 @@ public func gST2UT(_ gst:Date,timeZoneInSeconds: Int) -> Date{
         TZero -= 24
     }
     //Step9:
-    let gstDecimal = HMS.init(from: gst, timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    let gstDecimal = HMS.init(from: gst, timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     //Step10:
     var a = gstDecimal - TZero
@@ -394,14 +394,14 @@ public func gST2UT(_ gst:Date,timeZoneInSeconds: Int) -> Date{
 ///   - longitude: longitude of the observer
 ///   - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: LST equivalent for the GST given in input
-public func gST2LST(_ gst: Date, longitude: Angle,timeZoneInSeconds: Int) -> Date{
+public func gST2LST(_ gst: Date, longitude: Angle,timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ?  .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
     //Step1:
-    let gstDecimal = HMS.init(from: gst, timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    let gstDecimal = HMS.init(from: gst, timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     //Step2:
     let adjustment:Double = longitude.degrees / 15.0
@@ -441,14 +441,14 @@ public func gST2LST(_ gst: Date, longitude: Angle,timeZoneInSeconds: Int) -> Dat
 ///   - longitude: longitude of the observer
 ///   - Parameter timeZoneInSeconds: time zone expressed in seconds of your local civil time
 /// - Returns: GST equivalent for the LST given in input
-public func lST2GST(_ lst: Date, longitude: Angle,timeZoneInSeconds: Int) -> Date{
+public func lST2GST(_ lst: Date, longitude: Angle,timeZoneInSeconds: Int,useSameTimeZone: Bool) -> Date{
     
     var calendar: Calendar = .init(identifier: .gregorian)
-    let timeZone: TimeZone = .init(secondsFromGMT: timeZoneInSeconds) ?? .current
+    let timeZone: TimeZone = useSameTimeZone ?  .current : .init(secondsFromGMT: timeZoneInSeconds) ?? .current
     calendar.timeZone = timeZone
     
     //Step1:
-    let lstDecimal = HMS.init(from: lst, timeZoneInSeconds: timeZoneInSeconds).hMS2Decimal()
+    let lstDecimal = HMS.init(from: lst, timeZoneInSeconds: timeZoneInSeconds,useSameTimeZone: useSameTimeZone).hMS2Decimal()
     
     //Step2:
     let adjustment:Double = longitude.degrees / 15.0

--- a/Tests/SunKitTests/UT_Sun.swift
+++ b/Tests/SunKitTests/UT_Sun.swift
@@ -372,11 +372,12 @@ final class UT_Sun: XCTestCase {
        
         XCTAssertTrue(abs(expectedDecemberSolstice.timeIntervalSince1970 - sunUnderTest.decemberSolstice.timeIntervalSince1970)
                       <  UT_Sun.sunEquinoxesAndSolsticesThresholdInSeconds)
-        
-    
-        
-        
     }
+    
+    
+    
+    
+    
     
     func testPerformance() throws {
         // Performance of setDate function that will refresh all the sun variables

--- a/Tests/SunKitTests/UT_SunLitt.swift
+++ b/Tests/SunKitTests/UT_SunLitt.swift
@@ -1,0 +1,287 @@
+//
+//  UT_SunLitt.swift
+//
+//
+//  Copyright 2023 Leonardo Bertinelli, Davide Biancardi, Raffaele Fulgente, Clelia Iovine, Nicolas Mariniello, Fabio Pizzano
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import XCTest
+import Foundation
+import CoreLocation
+@testable import SunKit
+
+final class UT_SunLitt: XCTestCase {
+    
+    //Test suite created for SunLitt App.
+
+    /*--------------------------------------------------------------------
+     Thresholds. UTs will pass if |output - expectedOutput| < threshold
+     *-------------------------------------------------------------------*/
+    static let sunAzimuthThreshold: Double = 0.5
+    static let sunAltitudeThreshold: Double = 0.5
+    static let sunSetRiseThresholdInSeconds: Double = 300 //5 minutes in seconds
+    static let sunEquinoxesAndSolsticesThresholdInSeconds:Double = 1200 //20 minutes in seconds
+    
+    /*--------------------------------------------------------------------
+     Naples timezone and location
+     *-------------------------------------------------------------------*/
+    static let naplesLocation: CLLocation = .init(latitude: 40.84014, longitude: 14.25226)
+    static let timeZoneNaples = 1
+    static let timeZoneNaplesDaylightSaving = 2
+    
+    /*--------------------------------------------------------------------
+     Tokyo timezone and location
+     *-------------------------------------------------------------------*/
+    static let tokyoLocation: CLLocation = .init(latitude: 35.68946, longitude: 139.69172)
+    static let timeZoneTokyo = 9
+    
+    /*--------------------------------------------------------------------
+     Louisa USA timezone and location
+     *-------------------------------------------------------------------*/
+    static let louisaLocation: CLLocation = .init(latitude: 38, longitude: -78)
+    static let timeZoneLouisa = -5
+    static let timeZoneLouisaDaylightSaving = -4
+    
+    /*--------------------------------------------------------------------
+     Tromso circumpolar timezone and location
+     *-------------------------------------------------------------------*/
+    static let tromsoLocation: CLLocation = .init(latitude: 69.6489, longitude: 18.95508)
+    static let timeZoneTromso = 1
+    static let timeZoneTromsoDaylightSaving = 2
+    
+    /*--------------------------------------------------------------------
+     Mumbai  timezone and location
+     *-------------------------------------------------------------------*/
+    static let mumbaiLocation: CLLocation = .init(latitude: 18.94017, longitude: 72.83489)
+    static let timeZoneMumbai = 5.5
+    
+  
+    /// Test of  Sun azimuth, sunrise, sunset, afternoon golden hour start and afternoon golden hour end
+    /// Value for expected results have been taken from SunCalc.org
+    func testOfSun() throws {
+        
+        /*--------------------------------------------------------------------
+         Naples
+         *-------------------------------------------------------------------*/
+        
+        //Test1: 19/11/22 20:00. Timezone +1.
+        
+        //Step1: Creating Sun instance in Naples and with timezone +1
+        var sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: Double(UT_Sun.timeZoneNaples),useSameTimeZone: true)
+        
+        //Step2: Setting 19/11/22 20:00 as date. (No daylight saving)
+        var dateUnderTest = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 20, minute: 00, seconds: 00)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Saving expected outputs
+        var expectedAzimuth = 275.84
+        var expectedAltitude = -37.34
+        
+        var expectedSunRise = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 54, seconds: 12)
+        var expectedSunset = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 42, seconds: 07)
+        
+        var expectedGoldenHourStart = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 00, seconds: 00)
+        var expectedGoldenHourEnd = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 16, minute: 59, seconds: 00)
+        
+        var expectedFirstLight = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 6, minute: 24, seconds: 51)
+        var expectedLastLight = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 17, minute: 11, seconds: 28)
+        
+        var expectedSolarNoon = createDateCurrentTimeZone(day: 19, month: 11, year: 2022, hour: 11, minute: 48, seconds: 21)
+
+        //Step4: Check if the output are close to the expected ones
+        
+        XCTAssertTrue(abs(expectedAzimuth - sunUnderTest.azimuth.degrees) <  UT_Sun.sunAzimuthThreshold)
+        XCTAssertTrue(abs(expectedAltitude - sunUnderTest.altitude.degrees) <  UT_Sun.sunAltitudeThreshold)
+       
+        XCTAssertTrue(abs(expectedSunRise.timeIntervalSince1970 - sunUnderTest.sunrise.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSunset.timeIntervalSince1970 - sunUnderTest.sunset.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedGoldenHourStart.timeIntervalSince1970 - sunUnderTest.goldenHourStart.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedGoldenHourEnd.timeIntervalSince1970 - sunUnderTest.goldenHourEnd.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedFirstLight.timeIntervalSince1970 - sunUnderTest.firstLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        
+        //Test: 31/12/2024 15:32. Timezone +1. Leap Year.
+        
+        //Step1: Creating Sun instance in Naples and with timezone +1
+        sunUnderTest = Sun.init(location: UT_Sun.naplesLocation, timeZone: Double(UT_Sun.timeZoneNaples),useSameTimeZone: true)
+        
+        //Step2: Setting 31/12/2024 15:32 as date. (No daylight saving)
+        dateUnderTest = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 15, minute: 32, seconds: 00)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Saving expected outputs
+        expectedAzimuth = 226.99
+        expectedAltitude = 10.35
+        
+        expectedSunRise = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 7, minute: 26, seconds: 57)
+        expectedSunset = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 45, seconds: 32)
+        
+        expectedGoldenHourStart = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 16, minute: 02, seconds: 00)
+        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 05, seconds: 00)
+        
+        expectedFirstLight = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 6, minute: 56, seconds: 24)
+        expectedLastLight = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 17, minute: 16, seconds: 06)
+        
+        expectedSolarNoon = createDateCurrentTimeZone(day: 31, month: 12, year: 2024, hour: 12, minute: 06, seconds: 11)
+
+        //Step4: Check if the output are close to the expected ones
+        
+        XCTAssertTrue(abs(expectedAzimuth - sunUnderTest.azimuth.degrees) <  UT_Sun.sunAzimuthThreshold)
+        XCTAssertTrue(abs(expectedAltitude - sunUnderTest.altitude.degrees) <  UT_Sun.sunAltitudeThreshold)
+       
+        XCTAssertTrue(abs(expectedSunRise.timeIntervalSince1970 - sunUnderTest.sunrise.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSunset.timeIntervalSince1970 - sunUnderTest.sunset.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedGoldenHourStart.timeIntervalSince1970 - sunUnderTest.goldenHourStart.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedGoldenHourEnd.timeIntervalSince1970 - sunUnderTest.goldenHourEnd.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedFirstLight.timeIntervalSince1970 - sunUnderTest.firstLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        
+        
+        /*--------------------------------------------------------------------
+         Tokyo
+         *-------------------------------------------------------------------*/
+        
+        //Test: 1/08/22 16:50. Timezone +9.
+        
+        //Step1: Creating sun instance in Tokyo and with timezone +9
+        sunUnderTest = Sun.init(location: UT_Sun.tokyoLocation, timeZone: Double(UT_Sun.timeZoneTokyo),useSameTimeZone: true)
+        
+        //Step2: Setting 1/08/22 16:50 as date.
+        dateUnderTest = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 16, minute: 50, seconds: 00)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Saving expected outputs
+        expectedAzimuth = 276.98
+        expectedAltitude = 21.90
+        
+        expectedSunRise = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 48, seconds: 29)
+        expectedSunset = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 46, seconds: 15)
+        
+        expectedGoldenHourStart = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 18, minute: 11, seconds: 00)
+        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 04, seconds: 00)
+        
+        expectedFirstLight = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 4, minute: 20, seconds: 39)
+        expectedLastLight = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 19, minute: 14, seconds: 00)
+        
+        expectedSolarNoon = createDateCurrentTimeZone(day: 1, month: 8, year: 2022, hour: 11, minute: 47, seconds: 36)
+
+        //Step4: Check if the output are close to the expected ones
+        
+        XCTAssertTrue(abs(expectedAzimuth - sunUnderTest.azimuth.degrees) <  UT_Sun.sunAzimuthThreshold)
+        XCTAssertTrue(abs(expectedAltitude - sunUnderTest.altitude.degrees) <  UT_Sun.sunAltitudeThreshold)
+       
+        XCTAssertTrue(abs(expectedSunRise.timeIntervalSince1970 - sunUnderTest.sunrise.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSunset.timeIntervalSince1970 - sunUnderTest.sunset.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedGoldenHourStart.timeIntervalSince1970 - sunUnderTest.goldenHourStart.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedGoldenHourEnd.timeIntervalSince1970 - sunUnderTest.goldenHourEnd.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedFirstLight.timeIntervalSince1970 - sunUnderTest.firstLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+      
+        /*--------------------------------------------------------------------
+         Louisa USA
+         *-------------------------------------------------------------------*/
+        
+        //Test:  1/01/15 22:00. Timezone -5.
+        
+        //Step1: Creating sun instance in Louisa and with timezone -5 (No daylight saving)
+        sunUnderTest = Sun.init(location: UT_Sun.louisaLocation, timeZone: Double(UT_Sun.timeZoneLouisa),useSameTimeZone: true)
+        
+        //Step2: Setting 1/01/15 22:00 as date. (No daylight saving)
+        dateUnderTest = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 22, minute: 00, seconds: 00)
+        sunUnderTest.setDate(dateUnderTest)
+
+        //Step3: Saving expected outputs
+        expectedAzimuth = 287.62
+        expectedAltitude = -57.41
+        
+        expectedSunRise = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 7, minute: 27, seconds: 29)
+        expectedSunset = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 03, seconds: 25)
+        
+        expectedGoldenHourStart = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 16, minute: 22, seconds: 00)
+        expectedGoldenHourEnd = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 22, seconds: 00)
+        
+        expectedFirstLight = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 6, minute: 58, seconds: 28)
+        expectedLastLight = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 17, minute: 32, seconds: 27)
+        
+        expectedSolarNoon = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 12, minute: 15, seconds: 23)
+
+        //Step4: Check if the output are close to the expected ones
+        
+        XCTAssertTrue(abs(expectedAzimuth - sunUnderTest.azimuth.degrees) <  UT_Sun.sunAzimuthThreshold)
+        XCTAssertTrue(abs(expectedAltitude - sunUnderTest.altitude.degrees) <  UT_Sun.sunAltitudeThreshold)
+       
+        XCTAssertTrue(abs(expectedSunRise.timeIntervalSince1970 - sunUnderTest.sunrise.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSunset.timeIntervalSince1970 - sunUnderTest.sunset.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedGoldenHourStart.timeIntervalSince1970 - sunUnderTest.goldenHourStart.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedGoldenHourEnd.timeIntervalSince1970 - sunUnderTest.goldenHourEnd.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedFirstLight.timeIntervalSince1970 - sunUnderTest.firstLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+       
+        XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        
+        /*--------------------------------------------------------------------
+         Tromso circumpolar
+         *-------------------------------------------------------------------*/
+        
+        //Test: 19/01/22 17:31. Timezone +1.
+        
+        //Step1: Creating sun instance in Tromso and with timezone +1 (No daylight saving)
+        sunUnderTest = Sun.init(location: UT_Sun.tromsoLocation, timeZone: Double(UT_Sun.timeZoneTromso),useSameTimeZone: true)
+        
+        //Step2: Setting 19/01/22 17:31 as date. (No daylight saving)
+        dateUnderTest = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 17, minute: 31, seconds: 00)
+        sunUnderTest.setDate(dateUnderTest)
+        
+        //Step3: Saving expected outputs
+        expectedAzimuth = 257.20
+        expectedAltitude = -16.93
+        
+        expectedSunRise = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 10, minute: 41, seconds: 46)
+        expectedSunset = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 13, minute: 08, seconds: 48)
+        expectedFirstLight = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 08, minute: 45, seconds: 30)
+        expectedLastLight = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 15, minute: 05, seconds: 08)
+        
+        expectedSolarNoon = createDateCurrentTimeZone(day: 19, month: 1, year: 2022, hour: 11, minute: 54, seconds: 52)
+
+        //Step4: Check if the output are close to the expected ones
+        
+        XCTAssertTrue(abs(expectedAzimuth - sunUnderTest.azimuth.degrees) <  UT_Sun.sunAzimuthThreshold)
+        XCTAssertTrue(abs(expectedAltitude - sunUnderTest.altitude.degrees) <  UT_Sun.sunAltitudeThreshold)
+       
+        XCTAssertTrue(abs(expectedSunRise.timeIntervalSince1970 - sunUnderTest.sunrise.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSunset.timeIntervalSince1970 - sunUnderTest.sunset.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedFirstLight.timeIntervalSince1970 - sunUnderTest.firstLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedLastLight.timeIntervalSince1970 - sunUnderTest.lastLight.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        XCTAssertTrue(abs(expectedSolarNoon.timeIntervalSince1970 - sunUnderTest.solarNoon.timeIntervalSince1970) <  UT_Sun.sunSetRiseThresholdInSeconds)
+        
+    }
+    
+    
+
+}

--- a/Tests/SunKitTests/UT_Utils.swift
+++ b/Tests/SunKitTests/UT_Utils.swift
@@ -79,7 +79,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 1, month: 1, year: 2015, hour: 23, minute: 0, seconds: 0)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lCT2UT(dateUnderTest, timeZoneInSeconds: timeZoneInSecondsUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lCT2UT(dateUnderTest, timeZoneInSeconds: timeZoneInSecondsUnderTest,useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
     /// Test of UT2LCT
@@ -95,7 +95,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 11, month: 06, year: 2015, hour: 19, minute: 30, seconds: 0)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - UT2LCT(dateUnderTest, timeZoneInSeconds: timeZoneInSecondsUnderTest).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - UT2LCT(dateUnderTest, timeZoneInSeconds: timeZoneInSecondsUnderTest,useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
     /// Test of extendMod
@@ -155,7 +155,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 8, minute: 41, seconds: 53)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - uT2GST(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - uT2GST(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT(),useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
     /// Test of gST2UT
@@ -170,7 +170,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 23, minute: 30, seconds: 00)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2UT(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2UT(dateUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT(),useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
     /// Test of gST2LST
@@ -186,7 +186,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 6, month: 2, year: 2010, hour: 23, minute: 23, seconds: 41)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2LST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - gST2LST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT(),useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
     /// Test of lST2GST
@@ -202,7 +202,7 @@ final class UT_Utils: XCTestCase {
         let expectedOutput: Date = createDateCurrentTimeZone(day: 7, month: 2, year: 2010, hour: 20, minute: 3, seconds: 41)
         
         //Step3: Call function under test and check that it returns a value which differs from expected output up to 2 seconds
-        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lST2GST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT()).timeIntervalSince1970) <= 2)
+        XCTAssertTrue(abs(expectedOutput.timeIntervalSince1970 - lST2GST(dateUnderTest, longitude: longitudeUnderTest,timeZoneInSeconds: TimeZone.current.secondsFromGMT(),useSameTimeZone: false).timeIntervalSince1970) <= 2)
     }
     
 }


### PR DESCRIPTION
To switch to the old way on how timezones where handled, when initiliaze your Sun instance remember to set `useSameTimeZone = TRUE`.
The default behaviour from  now on will be with `useSameTimeZone = FALSE`.