### PR TITLE
Better handling of circumpolar always light conditions

### DIFF
--- a/Sources/SunKit/Sun.swift
+++ b/Sources/SunKit/Sun.swift
@@ -607,7 +607,7 @@ public class Sun {
         var sunriseSeconds    = (Int(sunriseUTCMinutes) * 60) + timeZoneInSeconds
         let startOfDay        = calendar.startOfDay(for: date)
         
-        if sunriseSeconds < 0 {
+        if sunriseSeconds < Int(SECONDS_IN_ONE_HOUR) {
             sunriseSeconds = 0
         }
         
@@ -658,7 +658,7 @@ public class Sun {
             
             secondsForSunToReachElevation = Double(SECONDS_IN_ONE_DAY)
         }
-        else if (secondsForSunToReachElevation < 0){
+        else if (secondsForSunToReachElevation < SECONDS_IN_ONE_HOUR){
             
             secondsForSunToReachElevation = 0
         }


### PR DESCRIPTION
Now if secondsToSunrise are below one hour, sunrise is considered irelevant(i.e sunrise will be at 00:00).
Same apply for Dawn events.